### PR TITLE
Fix issue with HtmlViewer not finding page resources

### DIFF
--- a/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/whatsappextractor/ReportGenerator.java
+++ b/iped-parsers/iped-parsers-impl/src/main/java/dpf/mg/udi/gpinf/whatsappextractor/ReportGenerator.java
@@ -32,8 +32,10 @@ public class ReportGenerator {
     private IItemSearcher searcher;
     private Chat lastChat;
     private int currentMsg = 0;
+    
+    public static final String RSRC_PREFIX = "../../../..";
 
-    static final String RSRC_PATH = "../../../../indexador/htm/whatsapp/"; //$NON-NLS-1$
+    static final String RSRC_PATH = RSRC_PREFIX + "/indexador/htm/whatsapp/"; //$NON-NLS-1$
 
     public ReportGenerator(IItemSearcher searcher) {
         this.searcher = searcher;

--- a/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/HtmlViewer.java
+++ b/iped-viewers/iped-viewers-impl/src/main/java/dpf/sp/gpinf/indexer/ui/fileViewer/frames/HtmlViewer.java
@@ -5,6 +5,8 @@ import java.awt.GridLayout;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Set;
 
@@ -60,11 +62,18 @@ public class HtmlViewer extends Viewer {
     private static String baseDir;
 
     static {
-        baseDir = System.getProperty("user.dir");
-        if (baseDir.contains("\\")) {
-            baseDir = baseDir.replaceAll("\\\\", "/");
+        try {
+            URL url = HtmlViewer.class.getProtectionDomain().getCodeSource().getLocation();
+            File root = new File(url.toURI()).getParentFile().getParentFile().getParentFile();
+            baseDir = root.getAbsolutePath();
+            if (baseDir.contains("\\")) {
+                baseDir = baseDir.replaceAll("\\\\", "/");
+            }
+            baseDir = "file:///" + baseDir;
+            
+        } catch (Exception e) {
+            e.printStackTrace();
         }
-        baseDir = "file:///" + baseDir;
     }
 
     @Override
@@ -333,8 +342,10 @@ public class HtmlViewer extends Viewer {
                         }
 
                         //change link and img elements
-                        fixResourceLocationOnNodesOfType(newDocument, "link", "href", "../../../..", baseDir);
-                        fixResourceLocationOnNodesOfType(newDocument, "img", "src", "../../../..", baseDir);
+                        if(baseDir != null) {
+                            fixResourceLocationOnNodesOfType(newDocument, "link", "href", "../../../..", baseDir);
+                            fixResourceLocationOnNodesOfType(newDocument, "img", "src", "../../../..", baseDir);
+                        }
                     }
                 });
             }


### PR DESCRIPTION
As IPED is now storing subitens in containers, the file passed to
HtmlViewer is located in a temporary folder, and the resources in the
default case folder. As some parsers generate HTML with relative paths,
the viewer cannot find these resources anymore. Fix by editing the tags
in html when it is loaded, fixing the reference.